### PR TITLE
Implement a basic request verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,74 @@
-# Sails
+# ⛵️ Sails ⛵️
 
-A description of this package.
+Sails is a lightweight, configurable mock server built to run alongside UI Tests for iOS and macOS applications - all
+written in Swift.
+
+### Usage
+
+Simply import Sails into your UI test, new up an `Application`, configure some endpoints, and start the server.
+
+```swift
+import Sails
+
+let server = Application()
+server.routes.post("/graphql") { request, _ in
+    Response(status: .ok)
+}
+try server.start()
+```
+
+### Verifying Requests
+
+Sails has the ability to determine whether or not a request was made to it. Let's look at the following example. Here
+we have a UI test that validates pull to refresh.
+
+```swift
+import XCTest
+import Sails
+
+class PullToRefreshTests: XCTestCase {
+    var server: Application!
+    var app: PocketAppElement!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        let uiApp = XCUIApplication()
+        app = PocketAppElement(app: uiApp)
+        
+        // Configure Sails to respond to a POST /graphql with a 200 and no body
+        server = Application()
+        server.routes.post("/graphql") { request, _ in
+            Response(status: .ok)
+        }
+        try server.start()
+
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        try server.stop()
+        app.terminate()
+    }
+
+    func test_myList_pullToRefresh_fetchesNewContent() {
+        app.tabBar.myListButton.wait().tap()
+
+        let listView = app.myListView.wait()
+        XCTAssertEqual(listView.itemCount, 2)
+
+        // On the fly, update the response to POST /graphql with a 200 and body
+        server.routes.post("/graphql") { _, _ in
+            Response(status: .ok, content: "updated-list")
+        }
+
+        listView.pullToRefresh()
+
+        listView.itemView(matching: "Updated Item 1").wait()
+        listView.itemView(matching: "Updated Item 2").wait()
+
+        // Ensure that only one request was made to POST /graphql
+        XCTAssertEqual(server.verify(.POST, "/graphql"), 1)
+    }
+}
+```

--- a/Sources/Sails/Method.swift
+++ b/Sources/Sails/Method.swift
@@ -1,0 +1,19 @@
+//
+// Created by Michael Pace on 3/19/22.
+//
+
+import Foundation
+import NIOHTTP1
+
+public enum Method {
+    case GET
+    case POST
+
+    init(rawValue: HTTPMethod) {
+        switch rawValue {
+        case HTTPMethod.GET: self = Method.GET
+        case HTTPMethod.POST: self = Method.POST
+        default: self = Method.GET
+        }
+    }
+}

--- a/Sources/Sails/RequestReceived.swift
+++ b/Sources/Sails/RequestReceived.swift
@@ -1,0 +1,13 @@
+//
+// Created by Michael Pace on 3/19/22.
+//
+
+import Foundation
+import NIOHTTP1
+
+struct RequestMade {
+    let method: Method
+    let uri: String
+}
+
+extension RequestMade: Hashable {}

--- a/Sources/Sails/Verifier.swift
+++ b/Sources/Sails/Verifier.swift
@@ -1,0 +1,9 @@
+//
+// Created by Michael Pace on 3/19/22.
+//
+
+import Foundation
+
+public protocol Verifier {
+    func verify(_ method: Method, _ uri: String) -> Int
+}

--- a/Tests/SailsTests/VerifierTests.swift
+++ b/Tests/SailsTests/VerifierTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import XCTest
+import AsyncHTTPClient
+
+@testable import Sails
+
+class VerifierTests: XCTestCase {
+    var subject: Application!
+
+    var client: HTTPClient!
+
+    override func setUpWithError() throws {
+        subject = Application()
+        client = HTTPClient(eventLoopGroupProvider: .createNew)
+
+        try subject.start()
+    }
+
+    override func tearDownWithError() throws {
+        try subject.stop()
+        try client.syncShutdown()
+    }
+
+    func test_verify__noRequestsHaveBeenMade__returnZero() throws {
+        subject.routes.get("/greeting") { _, _ in
+            Response(status: Status.ok, content: "hola")
+        }
+        subject.routes.post("/tasks") { _, _ in
+            Response(status: .ok)
+        }
+
+        XCTAssertEqual(subject.verify(Method.GET, "/greeting"), 0)
+        XCTAssertEqual(subject.verify(Method.POST, "/task"), 0)
+    }
+
+    func test_verify__requestsHaveBeenMade__verifierReturnsNumberOfCalls() throws {
+        subject.routes.get("/greeting") { _, _ in
+            Response(status: Status.ok, content: "hola")
+        }
+        subject.routes.post("/tasks") { request, _ in
+            Response(status: .ok)
+        }
+
+        _ = try client.get(url: "http://localhost:8080/greeting").wait()
+        _ = try client.post(url: "http://localhost:8080/tasks", body: .string("build a web framework")).wait()
+        _ = try client.get(url: "http://localhost:8080/greeting").wait()
+
+        XCTAssertEqual(subject.verify(Method.GET, "/greeting"), 2)
+        XCTAssertEqual(subject.verify(Method.POST, "/tasks"), 1)
+    }
+}


### PR DESCRIPTION
Took a stab at trying to implement request verification, ex:

```swift
import Sails

let server = Application()
server.routes.post("/graphql") { request, _ in
    Response(status: .ok)
}
try server.start()

// Boot the app - run UI tests

XCTAssertEqual(server.verify(.POST, "/graphql"), 1)
```

Currently, we only keep track of the number of calls - however, I imagine we could also delve into the order in which calls happened and/or provide more valuable querying than just HTTP method and the path.