### PR TITLE
Return 404 and log unregistered requests

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/SailsTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/SailsTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1330"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SailsTests"
+               BuildableName = "SailsTests"
+               BlueprintName = "SailsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "1081b0b0541f535ca088acdb56f5ca5598bc6247",
-          "version": "1.6.3"
+          "revision": "7a4dfe026f6ee0f8ad741b58df74c60af296365d",
+          "version": "1.9.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "6aa9347d9bc5bbfe6a84983aec955c17ffea96ef",
-          "version": "2.33.0"
+          "revision": "d6e3762e0a5f7ede652559f53623baf11006e17c",
+          "version": "2.39.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "326f7f9a8c8c8402e3691adac04911cac9f9d87f",
-          "version": "1.18.4"
+          "revision": "50c25c132b140e62b45e90b5a76f13ded02c8a46",
+          "version": "1.20.1"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "5e68c1ded15619bb281b273fa8c2d8fd7f7b2b7d",
-          "version": "2.16.1"
+          "revision": "b5260a31c2a72a89fa684f5efb3054d8725a2316",
+          "version": "2.18.0"
         }
       },
       {
@@ -60,8 +60,17 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "e7f5278a26442dc46783ba7e063643d524e414a0",
-          "version": "1.11.3"
+          "revision": "8ab824b140d0ebcd87e9149266ddc353e3705a3e",
+          "version": "1.11.4"
+        }
+      },
+      {
+        "package": "SwiftyBeaver",
+        "repositoryURL": "https://github.com/SwiftyBeaver/SwiftyBeaver.git",
+        "state": {
+          "branch": null,
+          "revision": "2c039501d6eeb4d4cd4aec4a8d884ad28862e044",
+          "version": "1.9.5"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "Sails",
-    products: [
+        products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "Sails",
@@ -14,16 +14,26 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0")
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0"),
+        .package(url: "https://github.com/SwiftyBeaver/SwiftyBeaver.git", .upToNextMajor(from: "1.9.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Sails",
-            dependencies: ["NIO", "NIOHTTP1", "NIOFoundationCompat"]),
+            dependencies: [
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
+                "SwiftyBeaver"
+            ]),
         .testTarget(
             name: "SailsTests",
-            dependencies: ["Sails", "AsyncHTTPClient"]),
+            dependencies: [
+                "Sails",
+                .product(name: "AsyncHTTPClient", package: "async-http-client")
+            ]
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -6,17 +6,27 @@ written in Swift.
 ## Usage
 -----------------
 
-Simply import Sails into your UI test, new up an `Application`, configure some endpoints, and start the server.
+Simply import Sails into your UI test, new up an `Application`, register some endpoints, and start the server.
 
 ```swift
 import Sails
 
 let server = Application()
+// register requests
 server.routes.post("/graphql") { request, _ in
     Response(status: .ok)
 }
 try server.start()
 ```
+
+Here we are registering a `POST` request to `localhost:8080/graphql` to respond with a 200 status code.
+
+### Unregistered requests
+
+Sails can also be a useful tool for auditing existing HTTP requests your iOS app is making. By default, Sails will 
+respond to requests not registered with a 404 and will log the following:
+
+`Uh oh! Sails has received an unregistered POST request from /some/uri`
 
 ### Verifying Requests
 

--- a/Sources/Sails/Application.swift
+++ b/Sources/Sails/Application.swift
@@ -1,23 +1,24 @@
 import Foundation
+
 import NIO
 import NIOHTTP1
-import NIOFoundationCompat
-import OSLog
 
 import XCTest
 
 public class Application {
     public let routes = Routes()
-    private let port: Int
+    private var requestsMap: [RequestMade: Int] = [:]
 
     private var group: EventLoopGroup?
     private var channel: Channel?
     private var bootstrap: ServerBootstrap?
 
-    private var requestsMap: [RequestMade: Int] = [:]
+    private let port: Int
+    private let logger: Loggable
 
-    public init(port: Int = 8080) {
+    public init(port: Int = 8080, logger: Loggable = SailsLogger()) {
         self.port = port
+        self.logger = logger
     }
 
     public func stop() throws {
@@ -33,34 +34,35 @@ public class Application {
         group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
         bootstrap = ServerBootstrap(group: group!)
-            .serverChannelOption(ChannelOptions.backlog, value: 256)
-            .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-            .childChannelInitializer { channel in
-                channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap { [weak self] in
-                    guard let app = self else {
-                        fatalError("Unable to add handler to pipeline because the application is no longer in memory")
-                    }
+                .serverChannelOption(ChannelOptions.backlog, value: 256)
+                .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+                .childChannelInitializer { channel in
+                    channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap { [weak self] in
+                        guard let app = self else {
+                            fatalError("Unable to add handler to pipeline because the application is no longer in memory")
+                        }
 
-                    return channel.pipeline.addHandler(app.handler())
+                        return channel.pipeline.addHandler(app.handler())
+                    }
                 }
-            }
-            .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
-            .childChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-            .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
+                .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+                .childChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+                .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
 
         channel = try bootstrap?.bind(host: "::1", port: port).wait()
     }
 
     private func handler() -> FunctionHandler {
-        return FunctionHandler() { [weak self] head in
+        FunctionHandler(logger: logger, getHandler: { [weak self] head in
             guard let self = self else {
                 fatalError("Unable to add handler to pipeline because the application is no longer in memory")
             }
 
-            self.requestsMap[RequestMade(method: Method.init(rawValue: head.method), uri: head.uri), default: 0] += 1
+            let requestMade = RequestMade(method: Method.init(rawValue: head.method), uri: head.uri)
+            self.requestsMap[requestMade, default: 0] += 1
 
             return self.routes.handler(for: head)
-        }
+        })
     }
 }
 
@@ -74,77 +76,6 @@ extension Application: Verifier {
 
         if callCount < 1 {
             XCTFail("Unable to verify request \(method) \(uri)\t", file: file, line: line)
-        }
-    }
-}
-
-class FunctionHandler: ChannelInboundHandler {
-    typealias InboundIn = HTTPServerRequestPart
-    typealias OutboundOut = HTTPServerResponsePart
-    typealias GetHandler = (HTTPRequestHead) -> RequestHandler?
-
-    private let getHandler: GetHandler
-    private var requestHead: HTTPRequestHead?
-    private var requestBody: ByteBuffer?
-
-    init(getHandler: @escaping GetHandler) {
-        self.getHandler = getHandler
-    }
-
-    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        let part = self.unwrapInboundIn(data)
-
-        switch part {
-        case .head(let head):
-            requestHead = head
-            requestBody = nil
-        case .body(var buffer):
-            if requestBody == nil {
-                requestBody = buffer
-            } else {
-                requestBody?.writeBuffer(&buffer)
-            }
-        case .end:
-            guard let head = requestHead else {
-                return
-            }
-
-            guard let handler = getHandler(head) else {
-                return
-            }
-
-            let request = Request(head: head, body: requestBody)
-            let response = handler(request, context.eventLoop)
-            send(response, via: context)
-        }
-    }
-
-    private func send(_ response: FutureResponse, via context: ChannelHandlerContext) {
-        var buffer = context.channel.allocator.buffer(capacity: 0)
-        response.response(on: context.eventLoop).whenSuccess { [weak self] response in
-            guard let self = self else {
-                return
-            }
-
-            let contentLength = try! response.content.encode(to: &buffer)
-            var headers = response.head.headers
-            headers.add(name: "Content-Length", value: String(contentLength))
-
-            let head = HTTPResponseHead(
-                version: HTTPVersion(major: 1, minor: 1),
-                status: response.head.status,
-                headers: headers
-            )
-
-            context.write(self.wrapOutboundOut(.head(head)), promise: nil)
-            context.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
-
-            let keepAlive = self.requestHead?.isKeepAlive == true
-            context.writeAndFlush(self.wrapOutboundOut(.end(nil))).whenComplete { _ in
-                if !keepAlive {
-                    context.close(promise: nil)
-                }
-            }
         }
     }
 }

--- a/Sources/Sails/FunctionHandler.swift
+++ b/Sources/Sails/FunctionHandler.swift
@@ -1,0 +1,86 @@
+//
+// Created by Michael Pace on 3/25/22.
+//
+
+import NIO
+import NIOHTTP1
+
+class FunctionHandler: ChannelInboundHandler {
+    typealias InboundIn = HTTPServerRequestPart
+    typealias OutboundOut = HTTPServerResponsePart
+    typealias GetHandler = (HTTPRequestHead) -> RequestHandler?
+
+    private var requestHead: HTTPRequestHead?
+    private var requestBody: ByteBuffer?
+
+    private let logger: Loggable
+    private let getHandler: GetHandler
+
+    init(logger: Loggable, getHandler: @escaping GetHandler) {
+        self.logger = logger
+        self.getHandler = getHandler
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let part = unwrapInboundIn(data)
+
+        switch part {
+        case .head(let head):
+            requestHead = head
+            requestBody = nil
+        case .body(var buffer):
+            if requestBody == nil {
+                requestBody = buffer
+            } else {
+                requestBody?.writeBuffer(&buffer)
+            }
+        case .end:
+            guard let head = requestHead else {
+                return
+            }
+
+            guard let handler = getHandler(head) else {
+                let uhOhResponse =  Response(
+                        status: .notFound,
+                        content: "Uh oh! Sails has received an unregistered \(head.method) head from \(head.uri)"
+                )
+                logger.error(request: RequestMade(method: Method.init(rawValue: head.method), uri: head.uri))
+                send(uhOhResponse, via: context)
+                return
+            }
+
+            let request = Request(head: head, body: requestBody)
+            let response = handler(request, context.eventLoop)
+            send(response, via: context)
+        }
+    }
+
+    private func send(_ response: FutureResponse, via context: ChannelHandlerContext) {
+        var buffer = context.channel.allocator.buffer(capacity: 0)
+        response.response(on: context.eventLoop).whenSuccess { [weak self] response in
+            guard let self = self else {
+                return
+            }
+
+            let contentLength = try! response.content.encode(to: &buffer)
+            var headers = response.head.headers
+            headers.add(name: "Content-Length", value: String(contentLength))
+
+            let head = HTTPResponseHead(
+                    version: HTTPVersion(major: 1, minor: 1),
+                    status: response.head.status,
+                    headers: headers
+            )
+
+            context.write(self.wrapOutboundOut(.head(head)), promise: nil)
+            context.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+
+            let keepAlive = self.requestHead?.isKeepAlive == true
+            context.writeAndFlush(self.wrapOutboundOut(.end(nil))).whenComplete { _ in
+                if !keepAlive {
+                    context.close(promise: nil)
+                }
+            }
+        }
+    }
+}

--- a/Sources/Sails/Loggable.swift
+++ b/Sources/Sails/Loggable.swift
@@ -1,0 +1,25 @@
+//
+// Created by Michael Pace on 3/25/22.
+//
+
+import Foundation
+import SwiftyBeaver
+
+
+public protocol Loggable {
+    func error(request: RequestMade)
+}
+
+public class SailsLogger: Loggable {
+    private let logger = SwiftyBeaver.self
+    private let console = ConsoleDestination()
+
+    public init() {
+        console.format = "$DHH:mm:ss$d $L $M"
+        logger.addDestination(console)
+    }
+
+    public func error(request: RequestMade) {
+        logger.error("Uh oh! Sails has received an unregistered \(request.method) request from \(request.uri)")
+    }
+}

--- a/Sources/Sails/Method.swift
+++ b/Sources/Sails/Method.swift
@@ -17,3 +17,12 @@ public enum Method {
         }
     }
 }
+
+extension Method: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .GET: return "GET"
+        case .POST: return "POST"
+        }
+    }
+}

--- a/Sources/Sails/RequestReceived.swift
+++ b/Sources/Sails/RequestReceived.swift
@@ -3,9 +3,8 @@
 //
 
 import Foundation
-import NIOHTTP1
 
-struct RequestMade {
+public struct RequestMade {
     let method: Method
     let uri: String
 }

--- a/Sources/Sails/Routing/Routes.swift
+++ b/Sources/Sails/Routing/Routes.swift
@@ -4,12 +4,6 @@ public class Routes {
     public typealias RoutesBuilder = (Routes) -> ()
     private let router: HTTPMethodRouter = HTTPMethodRouter<RequestHandler>()
     
-    public static func build(builder: RoutesBuilder) -> Routes {
-        let routes = Routes()
-        builder(routes)
-        return routes
-    }
-    
     public func get(_ uri: String, handler: @escaping RequestHandler) {
         router.add(.GET, uri: uri, value: handler)
     }

--- a/Tests/SailsTests/LoggableTests.swift
+++ b/Tests/SailsTests/LoggableTests.swift
@@ -4,7 +4,7 @@ import AsyncHTTPClient
 
 @testable import Sails
 
-class VerifierTests: XCTestCase {
+class LogableTests: XCTestCase {
     var subject: Application!
 
     var mockLogger: MockLogger!
@@ -24,39 +24,7 @@ class VerifierTests: XCTestCase {
         try client.syncShutdown()
     }
 
-    func test_verify__noRequestsHaveBeenMade__verifierFails() throws {
-        subject.routes.get("/greeting") { _, _ in
-            Response(status: Status.ok, content: "hola")
-        }
-        subject.routes.post("/tasks") { _, _ in
-            Response(status: .ok)
-        }
-
-        XCTExpectFailure("The following requests were not made; verification will fail") {
-            subject.verify(Method.GET, "/greeting")
-            subject.verify(Method.GET, "/greeting", times: 100)
-            subject.verify(Method.POST, "/task")
-            subject.verify(Method.POST, "/task", times: 100)
-        }
-    }
-
-    func test_verify__requestsHaveBeenMade__verifierPassesTest() throws {
-        subject.routes.get("/greeting") { _, _ in
-            Response(status: Status.ok, content: "hola")
-        }
-        subject.routes.post("/tasks") { request, _ in
-            Response(status: .ok)
-        }
-
-        _ = try client.get(url: "http://localhost:8080/greeting").wait()
-        _ = try client.post(url: "http://localhost:8080/tasks", body: .string("build a web framework")).wait()
-        _ = try client.get(url: "http://localhost:8080/greeting").wait()
-
-        subject.verify(Method.GET, "/greeting", times: 2)
-        subject.verify(Method.POST, "/tasks", times: 1)
-    }
-
-    func test_error__willExecuteForRequestsNotRegistered() throws {
+    func test_error_willExecuteForRequestsNotRegistered() throws {
         subject.routes.get("/greeting") { _, _ in
             Response(status: Status.ok, content: "hola")
         }

--- a/Tests/SailsTests/MockLogger.swift
+++ b/Tests/SailsTests/MockLogger.swift
@@ -1,0 +1,14 @@
+//
+// Created by Michael Pace on 3/25/22.
+//
+
+@testable import Sails
+
+class MockLogger: Loggable {
+    var lastRequestsErrored = [RequestMade]()
+
+    func error(request: RequestMade) {
+        lastRequestsErrored.append(request)
+    }
+}
+


### PR DESCRIPTION
Sails will now `log.error()` to the console and respond with a 404 status and the following content for requests that are made that **not registered**:

`Uh oh! Sails has received an unregistered POST request from /some/uri`

Some other things
- swift-tools-version is now the latest
- we are using [SwiftyBeaver](https://github.com/SwiftyBeaver/SwiftyBeaver) for logging (for now)
- split out `FunctionHandler` to its own file
- updated the README with more examples
- created a shared scheme for running unit tests